### PR TITLE
Add responsive header and welcome screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,10 @@
 #root {
-  max-width: 1280px;
+  max-width: 960px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 1rem;
+}
+
+.welcome {
   text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+  margin-top: 2rem;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,14 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import Header from './components/Header'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
     <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <Header />
+      <main className="welcome">
+        <h2>Welcome to myOura</h2>
+        <p>Connect your Oura account to begin.</p>
+      </main>
     </>
   )
 }
-
-export default App

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,0 +1,50 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background-color: #333;
+  color: #fff;
+}
+
+.header-title {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.menu-button {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 1.5rem;
+  height: 1.2rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.menu-button span {
+  display: block;
+  height: 2px;
+  background: currentColor;
+}
+
+.mobile-menu {
+  display: flex;
+  flex-direction: column;
+  margin-top: 0.5rem;
+  gap: 0.25rem;
+}
+
+.mobile-menu a {
+  color: inherit;
+  text-decoration: none;
+}
+
+@media (min-width: 768px) {
+  .menu-button,
+  .mobile-menu {
+    display: none;
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+import './Header.css'
+
+export default function Header() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <header className="header">
+      <h1 className="header-title">myOura</h1>
+      <button
+        className="menu-button"
+        onClick={() => setOpen(!open)}
+        aria-label="Toggle menu"
+      >
+        <span />
+        <span />
+        <span />
+      </button>
+      {open && (
+        <nav className="mobile-menu">
+          <a href="#">Home</a>
+          <a href="#">Stats</a>
+          <a href="#">Settings</a>
+        </nav>
+      )}
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- add `Header` component with hamburger menu
- show header and welcome message in `App`
- simplify `App.css`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852210a470483278744fffd234a06ae