### PR TITLE
Add header fixes and token field

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,9 +2,17 @@
   max-width: 960px;
   margin: 0 auto;
   padding: 1rem;
+  padding-top: 4rem;
 }
 
 .welcome {
   text-align: center;
   margin-top: 2rem;
+}
+
+.token-input {
+  width: 100%;
+  max-width: 400px;
+  padding: 0.5rem;
+  margin-top: 1rem;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,22 @@ export default function App() {
       <Header />
       <main className="welcome">
         <h2>Welcome to myOura</h2>
-        <p>Connect your Oura account to begin.</p>
+        <p>
+          Enter your personal access token from{' '}
+          <a
+            href="https://cloud.ouraring.com/personal-access-tokens"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Oura
+          </a>{' '}
+          to connect your account.
+        </p>
+        <input
+          type="text"
+          placeholder="Enter Oura access token"
+          className="token-input"
+        />
       </main>
     </>
   )

--- a/src/assets/logo.svg
+++ b/src/assets/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" stroke="#FFD700" stroke-width="10" fill="none"/>
+</svg>

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -5,11 +5,27 @@
   padding: 0.5rem 1rem;
   background-color: #333;
   color: #fff;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
 }
 
 .header-title {
   margin: 0;
   font-size: 1.5rem;
+}
+
+.logo {
+  width: 2rem;
+  height: 2rem;
+  margin-right: 0.5rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
 }
 
 .menu-button {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,16 @@
 import { useState } from 'react'
 import './Header.css'
+import logo from '../assets/logo.svg'
 
 export default function Header() {
   const [open, setOpen] = useState(false)
 
   return (
     <header className="header">
-      <h1 className="header-title">myOura</h1>
+      <div className="brand">
+        <img src={logo} alt="Oura logo" className="logo" />
+        <h1 className="header-title">myOura</h1>
+      </div>
       <button
         className="menu-button"
         onClick={() => setOpen(!open)}

--- a/src/index.css
+++ b/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- make the header fixed at the top
- add a simple gold ring logo and show it in the header
- update the body layout styles to work with a fixed header
- provide an input for the Oura personal access token with instructions

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685223f3ee808327b0946172f802e38d