### PR TITLE
Add Oura API link button and grid display

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -16,3 +16,25 @@
   padding: 0.5rem;
   margin-top: 1rem;
 }
+
+.link-button {
+  margin-top: 1rem;
+  background: #fff;
+  color: #000;
+  border: 1px solid #ccc;
+  border-radius: 0.5rem;
+}
+
+.data-grid {
+  margin-top: 2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+  text-align: left;
+}
+
+.grid-item {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 0.25rem;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,12 +8,15 @@ export default function App() {
 
   const handleConnect = async () => {
     try {
-      const response = await fetch(
-        'https://api.ouraring.com/v2/usercollection/personal-info',
-        {
-          headers: { Authorization: `Bearer ${token}` },
+    const response = await fetch(
+      'https://api.ouraring.com/v2/usercollection/personal_info',
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
         },
-      )
+      },
+    )
       if (!response.ok) {
         throw new Error('Failed to fetch data')
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,29 @@
+import { useState } from 'react'
 import './App.css'
 import Header from './components/Header'
 
 export default function App() {
+  const [token, setToken] = useState('')
+  const [userData, setUserData] = useState<Record<string, unknown> | null>(null)
+
+  const handleConnect = async () => {
+    try {
+      const response = await fetch(
+        'https://api.ouraring.com/v2/usercollection/personal-info',
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      )
+      if (!response.ok) {
+        throw new Error('Failed to fetch data')
+      }
+      const data = await response.json()
+      setUserData(data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
   return (
     <>
       <Header />
@@ -22,7 +44,22 @@ export default function App() {
           type="text"
           placeholder="Enter Oura access token"
           className="token-input"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
         />
+        <button className="link-button" onClick={handleConnect}>
+          Link Oura Ring
+        </button>
+        {userData && (
+          <div className="data-grid">
+            {Object.entries(userData).map(([key, value]) => (
+              <div key={key} className="grid-item">
+                <strong>{key}</strong>
+                <div>{JSON.stringify(value)}</div>
+              </div>
+            ))}
+          </div>
+        )}
       </main>
     </>
   )


### PR DESCRIPTION
## Summary
- add `Link Oura Ring` button
- implement fetch to Oura API
- display returned user data in a responsive grid
- style button and grid

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685226a6016083278e2689d2f41a7e39